### PR TITLE
Use script tags to include... scripts.

### DIFF
--- a/styleguide/_layouts/default.njk
+++ b/styleguide/_layouts/default.njk
@@ -47,7 +47,7 @@
   {# For example purposes only - you probably shouldn't do this in production! #}
   {% for component in components.all() %}
   {% for file in component.getFiles().filter('extname','.js').all() %}
-  <style>{{ file.contents }}</style>
+  <script>{{ file.contents }}</script>
   {% endfor %}
   {% endfor %}
 


### PR DESCRIPTION
The loop before the closing `</body>` tag picking out script files from components seems to want to put them in a `<style>` tag. I assume this should be a `<script>` tag instead?